### PR TITLE
Fix ANT amount miscalculation when generating tokens and assigning them to buyers

### DIFF
--- a/contracts/AragonTokenSale.sol
+++ b/contracts/AragonTokenSale.sol
@@ -261,7 +261,7 @@ Price increases by the same delta in every stage change
 
     if (totalCollected + msg.value > hardCap) throw; // If past hard cap, throw
 
-    uint256 boughtTokens = safeMul(msg.value, getPrice(getBlockNumber())); // Calculate how many tokens bought
+    uint256 boughtTokens = safeDiv(msg.value, getPrice(getBlockNumber())); // Calculate how many tokens bought
 
     if (!saleWallet.send(msg.value)) throw; // Send funds to multisig
     if (!token.generateTokens(_owner, boughtTokens)) throw; // Allocate tokens. This will fail after sale is finalized in case it is hidden cap finalized.


### PR DESCRIPTION
As far as I understand, the `getPrice` function in `AragonTokenSale.sol` returns the price that _1 ANT_ should have at a certain block height during the sale (`_blockNumber > initialBlock && _blockNumber < finalBlock`).

This price is returned as an `uint256` type, and therefore its value is expected to be an integer number in the interval `[0, 2**256 - 1]`, representing the price of _1 ANT_ expressed in _wei_.

`getPrice` gets called by the `doPayment` function also in `AragonTokenSale.sol` inside a certain line whose purpose is to calculate the amount of _ANT_ that one buyer can get in exchange for the amount of _wei_ contained in incoming transactions (`msg.amount`):

```
uint256 boughtTokens = safeMul(msg.value, getPrice(getBlockNumber()));
```

Now let's say that I send a _1 ETH_ worth in a transaction to this contract, and the price for the current block height is "_1 ANT_ = _1 finney_". 

* `msg.value` would be `1000000000000000000`
* `getPrice(getBlockNumber())` would return `1000000000000000`
*  `safeMul(msg.value, getPrice(getBlockNumber()))` would return... surprise: `1×10³³`

Wow... that's a huge amount of tokens!

The only case in which one would expect such multiplication to take place would be if `getPrice` returned the inverse price expressed as a value of type `double` or `float` in the `[0, 1]` interval, which is currently not possible in Solidity.
 
I believe the original intention was to use `safeDiv` instead like this:
```
uint256 boughtTokens = safeDiv(msg.value, getPrice(getBlockNumber()));
```
I guess the autocomplete feature in some code editor has played a dirty trick on someone!