### PR TITLE
Added missing return value

### DIFF
--- a/contracts/MiniMeIrrevocableVestedToken.sol
+++ b/contracts/MiniMeIrrevocableVestedToken.sol
@@ -208,6 +208,7 @@ contract MiniMeIrrevocableVestedToken is MiniMeToken, SafeMath {
     for (uint256 i = 0; i < grantIndex; i++) {
       date = max64(grants[holder][i].vesting, date);
     }
+    return date;
   }
 
   // @dev How many tokens can a holder transfer at a point in time


### PR DESCRIPTION
One liner missing, the function signature states a return value but there was none before.