### PR TITLE
rearrange overflow logic on the receiver address

### DIFF
--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -360,9 +360,9 @@ contract MiniMeToken is ERC20, Controlled {
     ) onlyController returns (bool) {
         uint curTotalSupply = getValueAt(totalSupplyHistory, block.number);
         if (curTotalSupply + _amount < curTotalSupply) throw; // Check for overflow
-        updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);
         var previousBalanceTo = balanceOf(_owner);
         if (previousBalanceTo + _amount < previousBalanceTo) throw; // Check for overflow
+        updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);
         updateValueAtNow(balances[_owner], previousBalanceTo + _amount);
         Transfer(0, _owner, _amount);
         return true;


### PR DESCRIPTION
The check to prevent overflow on receiver address should be before updating the `totalSupply`
 I have moved this line to the top `updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);`

the current code will increase the total supply but wouldn't assign the token to anyone!!

we are working on our crowdfund and was reviewing your code and notice this issue.